### PR TITLE
CLI 模式启动不再依赖 TK 库

### DIFF
--- a/Steganographier.py
+++ b/Steganographier.py
@@ -24,9 +24,6 @@ import sys
 import json
 import random
 import datetime
-import tkinter as tk
-from tkinter import  messagebox, ttk, filedialog
-from tkinterdnd2 import DND_FILES, TkinterDnD
 import pyzipper
 import zipfile
 import tempfile
@@ -45,10 +42,13 @@ import webbrowser
 import ctypes
 import psutil
 
-
-
-
-
+HAS_TK = True
+try:    
+    import tkinter as tk
+    from tkinter import  messagebox, ttk, filedialog
+    from tkinterdnd2 import DND_FILES, TkinterDnD
+except ImportError:
+    HAS_TK = False
 
 
 class ToolTip:
@@ -3589,6 +3589,9 @@ if __name__ == "__main__":
     
     # 根据模式显示/隐藏控制台
     if not is_cli_mode:
+        if not HAS_TK:
+            error("未安装Tkinter库，无法启动GUI模式")
+            sys.exit(1)
         hide_console()
     else:
         show_console()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
+altgraph==0.17.5
+hachoir==3.3.0
+natsort==8.4.0
+packaging==26.0
+pycryptodomex==3.23.0
 pyzipper==0.3.6
 tkinterdnd2==0.3.0


### PR DESCRIPTION
问题：在 Termux 的 Python 中，pip 无法正常解决 tkinter 依赖问题，导致 CLI 启动失败。
解决方案：使用 try-catch 包裹 tkinter 的导入，允许 CLI 模式在 tkinter 导入异常时运行。
